### PR TITLE
Add offline mission events with registration flow

### DIFF
--- a/backend/alembic/versions/20241015_0008_store_item_images.py
+++ b/backend/alembic/versions/20241015_0008_store_item_images.py
@@ -1,0 +1,20 @@
+"""Add image path to store items"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20241015_0008"
+down_revision = "3c5430b2cbd3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("store_items", sa.Column("image_url", sa.String(length=512), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("store_items", "image_url")

--- a/backend/alembic/versions/20241020_0009_offline_missions.py
+++ b/backend/alembic/versions/20241020_0009_offline_missions.py
@@ -1,0 +1,101 @@
+"""Add offline mission support"""
+
+from __future__ import annotations
+"""Add offline mission support."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20241020_0009"
+down_revision = "20241015_0008"
+branch_labels = None
+depends_on = None
+
+
+MISSION_FORMAT_ENUM = sa.Enum(
+    "online", "offline", name="missionformat", native_enum=False
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "missions",
+        sa.Column(
+            "format",
+            MISSION_FORMAT_ENUM,
+            nullable=False,
+            server_default="online",
+        ),
+    )
+    op.add_column(
+        "missions",
+        sa.Column("registration_deadline", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "missions",
+        sa.Column("starts_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "missions",
+        sa.Column("ends_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "missions",
+        sa.Column("location_title", sa.String(length=160), nullable=True),
+    )
+    op.add_column(
+        "missions",
+        sa.Column("location_address", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "missions",
+        sa.Column("location_url", sa.String(length=512), nullable=True),
+    )
+    op.add_column(
+        "missions",
+        sa.Column("capacity", sa.Integer(), nullable=True),
+    )
+
+    op.create_table(
+        "mission_registrations",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("mission_id", sa.Integer(), sa.ForeignKey("missions.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("mission_id", "user_id", name="uq_mission_registration"),
+    )
+    op.create_index(
+        "ix_mission_registrations_mission_id",
+        "mission_registrations",
+        ["mission_id"],
+    )
+    op.create_index(
+        "ix_mission_registrations_user_id",
+        "mission_registrations",
+        ["user_id"],
+    )
+
+    op.execute("UPDATE missions SET format='online' WHERE format IS NULL")
+    bind = op.get_bind()
+    if bind.dialect.name != "sqlite":
+        op.alter_column("missions", "format", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mission_registrations_user_id", table_name="mission_registrations")
+    op.drop_index("ix_mission_registrations_mission_id", table_name="mission_registrations")
+    op.drop_table("mission_registrations")
+
+    op.drop_column("missions", "capacity")
+    op.drop_column("missions", "location_url")
+    op.drop_column("missions", "location_address")
+    op.drop_column("missions", "location_title")
+    op.drop_column("missions", "ends_at")
+    op.drop_column("missions", "starts_at")
+    op.drop_column("missions", "registration_deadline")
+    op.drop_column("missions", "format")
+
+    MISSION_FORMAT_ENUM.drop(op.get_bind(), checkfirst=False)

--- a/backend/app/api/routes/store.py
+++ b/backend/app/api/routes/store.py
@@ -10,7 +10,7 @@ from app.db.session import get_db
 from app.models.store import Order, OrderStatus, StoreItem
 from app.models.user import User
 from app.schemas.store import OrderCreate, OrderRead, StoreItemRead
-from app.services.store import create_order, update_order_status
+from app.services.store import create_order, store_item_to_read, update_order_status
 
 router = APIRouter(prefix="/api/store", tags=["store"])
 
@@ -20,7 +20,7 @@ def list_items(*, db: Session = Depends(get_db)) -> list[StoreItemRead]:
     """Товары магазина."""
 
     items = db.query(StoreItem).order_by(StoreItem.name).all()
-    return [StoreItemRead.model_validate(item) for item in items]
+    return [store_item_to_read(item) for item in items]
 
 
 @router.post("/orders", response_model=OrderRead, summary="Создать заказ")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
-from alembic.script import ScriptDirectory
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
 
@@ -30,8 +30,9 @@ def run_migrations() -> None:
 
     config = Config(str(ALEMBIC_CONFIG))
     config.set_main_option("sqlalchemy.url", str(settings.database_url))
-    script = ScriptDirectory.from_config(config)
-    head_revision = script.get_current_head()
+    migrations_path = Path(__file__).resolve().parents[1] / "alembic"
+    config.set_main_option("script_location", str(migrations_path))
+    legacy_baseline = "20240927_0006"
 
     inspector = inspect(engine)
     tables = set(inspector.get_table_names())
@@ -60,6 +61,16 @@ def run_migrations() -> None:
                 conn.execute(text("ALTER TABLE users ADD COLUMN preferred_branch VARCHAR(160)"))
             if "motivation" not in user_columns:
                 conn.execute(text("ALTER TABLE users ADD COLUMN motivation TEXT"))
+            if "is_email_confirmed" not in user_columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE users ADD COLUMN is_email_confirmed BOOLEAN NOT NULL DEFAULT 1"
+                    )
+                )
+            if "email_confirmation_token" not in user_columns:
+                conn.execute(text("ALTER TABLE users ADD COLUMN email_confirmation_token VARCHAR(128)"))
+            if "email_confirmed_at" not in user_columns:
+                conn.execute(text("ALTER TABLE users ADD COLUMN email_confirmed_at DATETIME"))
 
             if "passport_path" not in submission_columns:
                 conn.execute(text("ALTER TABLE mission_submissions ADD COLUMN passport_path VARCHAR(512)"))
@@ -70,9 +81,7 @@ def run_migrations() -> None:
             if "resume_link" not in submission_columns:
                 conn.execute(text("ALTER TABLE mission_submissions ADD COLUMN resume_link VARCHAR(512)"))
 
-            conn.execute(text("CREATE TABLE IF NOT EXISTS alembic_version (version_num VARCHAR(32) NOT NULL)"))
-            conn.execute(text("DELETE FROM alembic_version"))
-            conn.execute(text("INSERT INTO alembic_version (version_num) VALUES (:rev)"), {"rev": head_revision})
+        command.stamp(config, legacy_baseline)
 
     command.upgrade(config, "head")
 
@@ -138,6 +147,8 @@ app.include_router(onboarding.router)
 app.include_router(store.router)
 app.include_router(python.router)
 app.include_router(admin.router)
+
+app.mount("/uploads", StaticFiles(directory=settings.uploads_path), name="uploads")
 
 
 @app.on_event("startup")

--- a/backend/app/models/store.py
+++ b/backend/app/models/store.py
@@ -30,6 +30,7 @@ class StoreItem(Base, TimestampMixin):
     description: Mapped[str] = mapped_column(Text, nullable=False)
     cost_mana: Mapped[int] = mapped_column(Integer, nullable=False)
     stock: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    image_url: Mapped[str | None] = mapped_column(String(512))
 
     orders: Mapped[List["Order"]] = relationship("Order", back_populates="item")
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -16,6 +16,7 @@ from app.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
     from app.models.coding import CodingAttempt
+    from app.models.mission import MissionRegistration
 
 class UserRole(str, Enum):
     """Типы ролей в системе."""
@@ -53,6 +54,9 @@ class User(Base, TimestampMixin):
     )
     submissions: Mapped[List["MissionSubmission"]] = relationship(
         "MissionSubmission", back_populates="user", cascade="all, delete-orphan"
+    )
+    mission_registrations: Mapped[List["MissionRegistration"]] = relationship(
+        "MissionRegistration", back_populates="user", cascade="all, delete-orphan"
     )
     orders: Mapped[List["Order"]] = relationship("Order", back_populates="user")
     journal_entries: Mapped[List["JournalEntry"]] = relationship(

--- a/backend/app/schemas/mission.py
+++ b/backend/app/schemas/mission.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, computed_field
 
-from app.models.mission import MissionDifficulty, SubmissionStatus
+from app.models.mission import MissionDifficulty, MissionFormat, SubmissionStatus
 
 
 class MissionBase(BaseModel):
@@ -19,6 +19,7 @@ class MissionBase(BaseModel):
     xp_reward: int
     mana_reward: int
     difficulty: MissionDifficulty
+    format: MissionFormat
     is_active: bool
     is_available: bool = True
     locked_reasons: list[str] = Field(default_factory=list)
@@ -27,6 +28,17 @@ class MissionBase(BaseModel):
     has_coding_challenges: bool = False
     coding_challenge_count: int = 0
     completed_coding_challenges: int = 0
+    registration_deadline: Optional[datetime] = None
+    starts_at: Optional[datetime] = None
+    ends_at: Optional[datetime] = None
+    location_title: Optional[str] = None
+    location_address: Optional[str] = None
+    location_url: Optional[str] = None
+    capacity: Optional[int] = None
+    registered_count: int = 0
+    spots_left: Optional[int] = None
+    is_registration_open: bool = False
+    is_registered: bool = False
 
     class Config:
         from_attributes = True
@@ -67,12 +79,20 @@ class MissionCreate(BaseModel):
     xp_reward: int
     mana_reward: int
     difficulty: MissionDifficulty = MissionDifficulty.MEDIUM
+    format: MissionFormat = MissionFormat.ONLINE
     minimum_rank_id: Optional[int] = None
     artifact_id: Optional[int] = None
     prerequisite_ids: list[int] = []
     competency_rewards: list[MissionCreateReward] = []
     branch_id: Optional[int] = None
     branch_order: int = 1
+    registration_deadline: Optional[datetime] = None
+    starts_at: Optional[datetime] = None
+    ends_at: Optional[datetime] = None
+    location_title: Optional[str] = None
+    location_address: Optional[str] = None
+    location_url: Optional[str] = None
+    capacity: Optional[int] = None
 
 
 class MissionUpdate(BaseModel):
@@ -83,6 +103,7 @@ class MissionUpdate(BaseModel):
     xp_reward: Optional[int] = None
     mana_reward: Optional[int] = None
     difficulty: Optional[MissionDifficulty] = None
+    format: Optional[MissionFormat] = None
     minimum_rank_id: Optional[int | None] = None
     artifact_id: Optional[int | None] = None
     prerequisite_ids: Optional[list[int]] = None
@@ -90,6 +111,13 @@ class MissionUpdate(BaseModel):
     branch_id: Optional[int | None] = None
     branch_order: Optional[int] = None
     is_active: Optional[bool] = None
+    registration_deadline: Optional[datetime | None] = None
+    starts_at: Optional[datetime | None] = None
+    ends_at: Optional[datetime | None] = None
+    location_title: Optional[str | None] = None
+    location_address: Optional[str | None] = None
+    location_url: Optional[str | None] = None
+    capacity: Optional[int | None] = None
 
 
 class MissionSubmissionCreate(BaseModel):

--- a/backend/app/schemas/store.py
+++ b/backend/app/schemas/store.py
@@ -18,9 +18,20 @@ class StoreItemRead(BaseModel):
     description: str
     cost_mana: int
     stock: int
+    image_url: Optional[str] = None
 
     class Config:
         from_attributes = True
+
+
+class StoreItemUpdate(BaseModel):
+    """Частичное обновление товара."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    cost_mana: Optional[int] = None
+    stock: Optional[int] = None
+    image_url: Optional[str] = None
 
 
 class OrderRead(BaseModel):

--- a/backend/app/services/store.py
+++ b/backend/app/services/store.py
@@ -9,6 +9,29 @@ from app.models.journal import JournalEventType
 from app.models.store import Order, OrderStatus, StoreItem
 from app.models.user import User
 from app.services.journal import log_event
+from app.schemas.store import StoreItemRead
+
+
+def build_store_image_url(relative_path: str | None) -> str | None:
+    """Преобразуем относительный путь в публичный URL."""
+
+    if not relative_path:
+        return None
+    normalized = relative_path.lstrip("/")
+    return f"/uploads/{normalized}"
+
+
+def store_item_to_read(item: StoreItem) -> StoreItemRead:
+    """Готовим схему товара с публичным URL изображения."""
+
+    return StoreItemRead(
+        id=item.id,
+        name=item.name,
+        description=item.description,
+        cost_mana=item.cost_mana,
+        stock=item.stock,
+        image_url=build_store_image_url(item.image_url),
+    )
 
 
 def create_order(db: Session, user: User, item: StoreItem, comment: str | None) -> Order:

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -3,6 +3,7 @@ import { AdminMissionManager } from '../../components/admin/AdminMissionManager'
 import { AdminRankManager } from '../../components/admin/AdminRankManager';
 import { AdminArtifactManager } from '../../components/admin/AdminArtifactManager';
 import { AdminSubmissionCard } from '../../components/admin/AdminSubmissionCard';
+import { AdminStoreManager } from '../../components/admin/AdminStoreManager';
 import { apiFetch } from '../../lib/api';
 import { requireRole } from '../../lib/auth/session';
 
@@ -29,6 +30,14 @@ interface MissionSummary {
   mana_reward: number;
   difficulty: 'easy' | 'medium' | 'hard';
   is_active: boolean;
+  format: 'online' | 'offline';
+  registration_deadline: string | null;
+  starts_at: string | null;
+  ends_at: string | null;
+  location_title: string | null;
+  location_address: string | null;
+  location_url: string | null;
+  capacity: number | null;
 }
 
 interface BranchSummary {
@@ -61,6 +70,15 @@ interface ArtifactSummary {
   image_url?: string | null;
 }
 
+interface StoreItemSummary {
+  id: number;
+  name: string;
+  description: string;
+  cost_mana: number;
+  stock: number;
+  image_url?: string | null;
+}
+
 interface SubmissionStats {
   pending: number;
   approved: number;
@@ -85,13 +103,14 @@ export default async function AdminPage() {
   // Админ-панель доступна только HR-сотрудникам; проверяем роль до загрузки данных.
   const session = await requireRole('hr');
 
-  const [submissions, missions, branches, ranks, competencies, artifacts, stats] = await Promise.all([
+  const [submissions, missions, branches, ranks, competencies, artifacts, storeItems, stats] = await Promise.all([
     apiFetch<Submission[]>('/api/admin/submissions', { authToken: session.token }),
     apiFetch<MissionSummary[]>('/api/admin/missions', { authToken: session.token }),
     apiFetch<BranchSummary[]>('/api/admin/branches', { authToken: session.token }),
     apiFetch<RankSummary[]>('/api/admin/ranks', { authToken: session.token }),
     apiFetch<CompetencySummary[]>('/api/admin/competencies', { authToken: session.token }),
     apiFetch<ArtifactSummary[]>('/api/admin/artifacts', { authToken: session.token }),
+    apiFetch<StoreItemSummary[]>('/api/admin/store/items', { authToken: session.token }),
     apiFetch<AdminStats>('/api/admin/stats', { authToken: session.token })
   ]);
 
@@ -165,6 +184,7 @@ export default async function AdminPage() {
           competencies={competencies}
           artifacts={artifacts}
         />
+        <AdminStoreManager token={session.token} items={storeItems} />
         <AdminRankManager token={session.token} ranks={ranks} missions={missions} competencies={competencies} />
         <AdminArtifactManager token={session.token} artifacts={artifacts} />
       </div>

--- a/frontend/src/app/missions/[id]/page.tsx
+++ b/frontend/src/app/missions/[id]/page.tsx
@@ -2,6 +2,7 @@ import { apiFetch } from '../../../lib/api';
 import { requireSession } from '../../../lib/auth/session';
 import { MissionSubmissionForm } from '../../../components/MissionSubmissionForm';
 import { CodingMissionPanel } from '../../../components/CodingMissionPanel';
+import { MissionRegistrationPanel } from '../../../components/MissionRegistrationPanel';
 
 interface MissionDetail {
   id: number;
@@ -10,6 +11,7 @@ interface MissionDetail {
   xp_reward: number;
   mana_reward: number;
   difficulty: string;
+  format: 'online' | 'offline';
   minimum_rank_id: number | null;
   artifact_id: number | null;
   prerequisites: number[];
@@ -25,6 +27,17 @@ interface MissionDetail {
   has_coding_challenges: boolean;
   coding_challenge_count: number;
   completed_coding_challenges: number;
+  registration_deadline: string | null;
+  starts_at: string | null;
+  ends_at: string | null;
+  location_title: string | null;
+  location_address: string | null;
+  location_url: string | null;
+  capacity: number | null;
+  registered_count: number;
+  spots_left: number | null;
+  is_registration_open: boolean;
+  is_registered: boolean;
 }
 
 async function fetchMission(id: number, token: string) {
@@ -85,6 +98,22 @@ export default async function MissionPage({ params }: MissionPageProps) {
       })
     : null;
 
+  const isOffline = mission.format === 'offline';
+  const dateFormatter = new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+  const timeFormatter = new Intl.DateTimeFormat('ru-RU', {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+  const startText = mission.starts_at ? dateFormatter.format(new Date(mission.starts_at)) : null;
+  const endDate = mission.ends_at ? new Date(mission.ends_at) : null;
+  const endText = endDate ? timeFormatter.format(endDate) : null;
+  const deadlineText = mission.registration_deadline ? dateFormatter.format(new Date(mission.registration_deadline)) : null;
+
   return (
     <section>
       <h2>{mission.title}</h2>
@@ -97,6 +126,43 @@ export default async function MissionPage({ params }: MissionPageProps) {
         <p style={{ marginTop: '0.5rem', color: 'var(--accent-light)' }}>
           Прогресс тренажёра: {mission.completed_coding_challenges}/{mission.coding_challenge_count} заданий
         </p>
+      )}
+      {isOffline && (
+        <div className="card" style={{ marginTop: '1rem' }}>
+          <h3>Офлайн-мероприятие</h3>
+          {startText && (
+            <p style={{ marginTop: '0.5rem' }}>
+              🗓 {startText}
+              {endText ? ` · до ${endText}` : ''}
+            </p>
+          )}
+          {mission.location_title && (
+            <p style={{ marginTop: '0.25rem' }}>
+              📍 {mission.location_title}
+              {mission.location_address ? ` — ${mission.location_address}` : ''}
+            </p>
+          )}
+          {mission.location_url && (
+            <p style={{ marginTop: '0.25rem' }}>
+              <a className="secondary" href={mission.location_url} target="_blank" rel="noreferrer">
+                Открыть карту
+              </a>
+            </p>
+          )}
+          {mission.capacity !== null && (
+            <p style={{ marginTop: '0.25rem' }}>
+              👥 Мест осталось: {mission.spots_left ?? 0} из {mission.capacity}
+            </p>
+          )}
+          {deadlineText && (
+            <p style={{ marginTop: '0.25rem', color: 'var(--accent-light)' }}>
+              Регистрация до {deadlineText}
+            </p>
+          )}
+          {mission.is_registered && (
+            <p style={{ marginTop: '0.25rem', color: 'var(--success)' }}>Вы уже зарегистрированы на мероприятие.</p>
+          )}
+        </div>
       )}
       {mission.is_completed && (
         <div
@@ -142,6 +208,17 @@ export default async function MissionPage({ params }: MissionPageProps) {
           token={session.token}
           initialState={codingState}
           initialCompleted={mission.is_completed}
+        />
+      ) : isOffline ? (
+        <MissionRegistrationPanel
+          missionId={mission.id}
+          token={session.token}
+          isRegistered={mission.is_registered}
+          isRegistrationOpen={mission.is_registration_open}
+          registeredCount={mission.registered_count}
+          spotsLeft={mission.spots_left}
+          registrationDeadline={mission.registration_deadline}
+          startsAt={mission.starts_at}
         />
       ) : (
         <MissionSubmissionForm

--- a/frontend/src/app/store/page.tsx
+++ b/frontend/src/app/store/page.tsx
@@ -8,6 +8,7 @@ interface StoreItem {
   description: string;
   cost_mana: number;
   stock: number;
+  image_url?: string | null;
 }
 
 async function fetchStore(token: string) {

--- a/frontend/src/components/MissionList.tsx
+++ b/frontend/src/components/MissionList.tsx
@@ -9,6 +9,7 @@ export interface MissionSummary {
   xp_reward: number;
   mana_reward: number;
   difficulty: string;
+  format: 'online' | 'offline';
   is_active: boolean;
   is_available: boolean;
   locked_reasons: string[];
@@ -17,6 +18,17 @@ export interface MissionSummary {
   has_coding_challenges: boolean;
   coding_challenge_count: number;
   completed_coding_challenges: number;
+  registration_deadline: string | null;
+  starts_at: string | null;
+  ends_at: string | null;
+  location_title: string | null;
+  location_address: string | null;
+  location_url: string | null;
+  capacity: number | null;
+  registered_count: number;
+  spots_left: number | null;
+  is_registration_open: boolean;
+  is_registered: boolean;
 }
 
 const Card = styled.div`
@@ -31,20 +43,58 @@ export function MissionList({ missions }: { missions: MissionSummary[] }) {
     return <p>Нет активных миссий — скоро появятся новые испытания.</p>;
   }
 
+  const dateFormatter = new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+
+  const timeFormatter = new Intl.DateTimeFormat('ru-RU', {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+
+  const formatDateTime = (value: string | null) => {
+    if (!value) return null;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return dateFormatter.format(date);
+  };
+
   return (
     <div className="grid">
       {missions.map((mission) => {
         const completed = mission.is_completed;
         const locked = !mission.is_available && !completed;
-        const primaryClass = completed ? 'secondary' : locked ? 'secondary' : 'primary';
-        const linkDisabled = locked;
-        const actionLabel = completed
+        const isOffline = mission.format === 'offline';
+        let linkDisabled = locked;
+        let actionClass = completed ? 'secondary' : locked ? 'secondary' : 'primary';
+        let actionLabel = completed
           ? 'Миссия выполнена'
           : mission.is_available
           ? mission.has_coding_challenges
             ? 'Решать задачи'
             : 'Открыть брифинг'
           : 'Заблокировано';
+
+        if (isOffline) {
+          if (mission.is_registered) {
+            actionLabel = 'Подробнее';
+            actionClass = 'secondary';
+          } else if (mission.is_registration_open && mission.is_available) {
+            actionLabel = 'Записаться';
+          } else {
+            actionLabel = 'Подробнее';
+            actionClass = 'secondary';
+          }
+          linkDisabled = locked;
+        }
+
+        const startText = formatDateTime(mission.starts_at);
+        const endDate = mission.ends_at ? new Date(mission.ends_at) : null;
+        const endText = endDate ? timeFormatter.format(endDate) : null;
+        const deadlineText = formatDateTime(mission.registration_deadline);
 
         return (
           <Card key={mission.id} style={completed ? { opacity: 0.85 } : undefined}>
@@ -64,12 +114,45 @@ export function MissionList({ missions }: { missions: MissionSummary[] }) {
                 💻 Прогресс: {mission.completed_coding_challenges}/{mission.coding_challenge_count} заданий
               </p>
             )}
+            {isOffline && (
+              <div style={{ marginTop: '0.75rem', fontSize: '0.9rem', lineHeight: 1.5 }}>
+                <strong>Офлайн-мероприятие</strong>
+                {startText && (
+                  <p style={{ marginTop: '0.25rem' }}>
+                    🗓 {startText}
+                    {endText ? ` · до ${endText}` : ''}
+                  </p>
+                )}
+                {mission.location_title && (
+                  <p style={{ marginTop: '0.25rem' }}>
+                    📍 {mission.location_title}
+                    {mission.location_address ? ` — ${mission.location_address}` : ''}
+                  </p>
+                )}
+                {mission.capacity !== null && (
+                  <p style={{ marginTop: '0.25rem' }}>
+                    👥 Свободных мест: {mission.spots_left ?? 0} из {mission.capacity}
+                  </p>
+                )}
+                {mission.is_registered ? (
+                  <p style={{ marginTop: '0.25rem', color: 'var(--success)' }}>Вы уже записаны на мероприятие.</p>
+                ) : mission.is_registration_open ? (
+                  deadlineText && (
+                    <p style={{ marginTop: '0.25rem', color: 'var(--accent-light)' }}>
+                      Регистрация открыта до {deadlineText}
+                    </p>
+                  )
+                ) : (
+                  <p style={{ marginTop: '0.25rem', color: 'var(--text-muted)' }}>Регистрация закрыта.</p>
+                )}
+              </div>
+            )}
             <p style={{ marginTop: '1rem' }}>{mission.xp_reward} XP · {mission.mana_reward} ⚡</p>
             {locked && mission.locked_reasons.length > 0 && (
               <p style={{ color: 'var(--error)', fontSize: '0.85rem' }}>{mission.locked_reasons[0]}</p>
             )}
             <a
-              className={primaryClass}
+              className={actionClass}
               style={{
                 display: 'inline-block',
                 marginTop: '1rem',

--- a/frontend/src/components/MissionRegistrationPanel.tsx
+++ b/frontend/src/components/MissionRegistrationPanel.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { apiFetch } from '../lib/api';
+
+interface MissionRegistrationPanelProps {
+  missionId: number;
+  token: string;
+  isRegistered: boolean;
+  isRegistrationOpen: boolean;
+  registeredCount: number;
+  spotsLeft: number | null;
+  registrationDeadline: string | null;
+  startsAt: string | null;
+}
+
+export function MissionRegistrationPanel({
+  missionId,
+  token,
+  isRegistered,
+  isRegistrationOpen,
+  registeredCount,
+  spotsLeft,
+  registrationDeadline,
+  startsAt
+}: MissionRegistrationPanelProps) {
+  const router = useRouter();
+  const [registered, setRegistered] = useState(isRegistered);
+  const [pending, setPending] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [count, setCount] = useState(registeredCount);
+  const [spots, setSpots] = useState<number | null>(spotsLeft);
+
+  const dateFormatter = new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+
+  const startText = startsAt ? dateFormatter.format(new Date(startsAt)) : null;
+  const deadlineText = registrationDeadline ? dateFormatter.format(new Date(registrationDeadline)) : null;
+
+  const handleRegister = async () => {
+    if (registered || pending || !isRegistrationOpen) {
+      return;
+    }
+    setPending(true);
+    setStatus(null);
+    try {
+      await apiFetch(`/api/missions/${missionId}/register`, {
+        method: 'POST',
+        authToken: token
+      });
+      setRegistered(true);
+      setStatus('Вы успешно записались! Напомним о встрече ближе к дате.');
+      setCount((prev) => prev + 1);
+      setSpots((prev) => (prev === null ? prev : Math.max(prev - 1, 0)));
+      router.refresh();
+    } catch (error) {
+      if (error instanceof Error) {
+        setStatus(error.message);
+      } else {
+        setStatus('Не удалось записаться. Попробуйте повторить позже.');
+      }
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className="card" style={{ marginTop: '2rem' }}>
+      <h3>Регистрация</h3>
+      <p style={{ marginTop: '0.5rem', color: 'var(--text-muted)' }}>
+        Участников: {count}
+        {spots !== null ? ` · свободно: ${spots}` : ''}
+      </p>
+      {startText && (
+        <p style={{ marginTop: '0.25rem', color: 'var(--accent-light)' }}>Старт мероприятия: {startText}</p>
+      )}
+      {deadlineText && (
+        <p style={{ marginTop: '0.25rem', color: 'var(--accent-light)' }}>Регистрация до {deadlineText}</p>
+      )}
+      {registered ? (
+        <p style={{ marginTop: '0.75rem', color: 'var(--success)' }}>
+          Вы уже зарегистрированы. Ждём на площадке!
+        </p>
+      ) : isRegistrationOpen ? (
+        <button type="button" className="primary" onClick={handleRegister} disabled={pending} style={{ marginTop: '1rem' }}>
+          {pending ? 'Отправка...' : 'Записаться'}
+        </button>
+      ) : (
+        <p style={{ marginTop: '0.75rem', color: 'var(--text-muted)' }}>Регистрация закрыта.</p>
+      )}
+      {status && <p style={{ marginTop: '0.75rem', color: registered ? 'var(--success)' : 'var(--error)' }}>{status}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/StoreItems.tsx
+++ b/frontend/src/components/StoreItems.tsx
@@ -10,6 +10,7 @@ type StoreItem = {
   description: string;
   cost_mana: number;
   stock: number;
+  image_url?: string | null;
 };
 
 const Card = styled.div`
@@ -17,6 +18,29 @@ const Card = styled.div`
   border-radius: 14px;
   padding: 1.25rem;
   border: 1px solid rgba(108, 92, 231, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+const ItemImage = styled.img`
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid rgba(108, 92, 231, 0.35);
+  background: rgba(108, 92, 231, 0.08);
+`;
+
+const ImagePlaceholder = styled.div`
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 10px;
+  border: 1px dashed rgba(108, 92, 231, 0.35);
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+  background: rgba(108, 92, 231, 0.05);
 `;
 
 type Feedback = { kind: 'success' | 'error'; text: string } | null;
@@ -68,12 +92,23 @@ export function StoreItems({ items, token }: { items: StoreItem[]; token?: strin
       <div className="grid">
         {items.map((item) => (
           <Card key={item.id}>
-            <h3 style={{ marginBottom: '0.5rem' }}>{item.name}</h3>
-            <p style={{ color: 'var(--text-muted)' }}>{item.description}</p>
-            <p style={{ marginTop: '1rem' }}>{item.cost_mana} ⚡ · остаток {item.stock}</p>
+            {item.image_url ? (
+              <ItemImage
+                src={item.image_url}
+                alt={`Изображение товара «${item.name}»`}
+                loading="lazy"
+              />
+            ) : (
+              <ImagePlaceholder>Изображение появится позже</ImagePlaceholder>
+            )}
+            <div>
+              <h3 style={{ marginBottom: '0.5rem' }}>{item.name}</h3>
+              <p style={{ color: 'var(--text-muted)', margin: 0 }}>{item.description}</p>
+            </div>
+            <p style={{ margin: 0 }}>{item.cost_mana} ⚡ · остаток {item.stock}</p>
             <button
               className="primary"
-              style={{ marginTop: '1rem' }}
+              style={{ marginTop: 'auto' }}
               onClick={() => handlePurchase(item.id)}
               disabled={item.stock === 0 || !token || loadingId === item.id}
             >

--- a/frontend/src/components/admin/AdminStoreManager.tsx
+++ b/frontend/src/components/admin/AdminStoreManager.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+import { ChangeEvent, FormEvent, useState } from 'react';
+import styled from 'styled-components';
+
+import { apiFetch } from '../../lib/api';
+
+interface StoreItem {
+  id: number;
+  name: string;
+  description: string;
+  cost_mana: number;
+  stock: number;
+  image_url?: string | null;
+}
+
+interface Feedback {
+  kind: 'success' | 'error';
+  text: string;
+}
+
+const SectionCard = styled.div`
+  background: rgba(17, 22, 51, 0.8);
+  border-radius: 16px;
+  padding: 1.5rem;
+  border: 1px solid rgba(108, 92, 231, 0.25);
+  display: grid;
+  gap: 1.5rem;
+`;
+
+const ItemsGrid = styled.div`
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+`;
+
+const ItemCard = styled.div`
+  background: rgba(10, 15, 40, 0.75);
+  border-radius: 14px;
+  padding: 1.25rem;
+  border: 1px solid rgba(108, 92, 231, 0.25);
+  display: grid;
+  gap: 1rem;
+`;
+
+const ItemImage = styled.img`
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 1px solid rgba(108, 92, 231, 0.35);
+  background: rgba(108, 92, 231, 0.08);
+`;
+
+const ImagePlaceholder = styled.div`
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 12px;
+  border: 1px dashed rgba(108, 92, 231, 0.35);
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+  background: rgba(108, 92, 231, 0.05);
+`;
+
+const FieldGroup = styled.div`
+  display: grid;
+  gap: 0.5rem;
+`;
+
+const InlineFields = styled.div`
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+`;
+
+const Label = styled.label`
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+`;
+
+const TextInput = styled.input`
+  border-radius: 8px;
+  border: 1px solid rgba(108, 92, 231, 0.35);
+  background: rgba(9, 13, 34, 0.8);
+  padding: 0.5rem 0.75rem;
+  color: var(--text-primary);
+`;
+
+const TextArea = styled.textarea`
+  border-radius: 8px;
+  border: 1px solid rgba(108, 92, 231, 0.35);
+  background: rgba(9, 13, 34, 0.8);
+  padding: 0.5rem 0.75rem;
+  color: var(--text-primary);
+  min-height: 96px;
+  resize: vertical;
+`;
+
+const FileInput = styled.input`
+  border-radius: 8px;
+  border: 1px dashed rgba(108, 92, 231, 0.35);
+  padding: 0.5rem;
+  background: rgba(9, 13, 34, 0.6);
+`;
+
+const Actions = styled.div`
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+`;
+
+const Message = styled.p<{ kind: 'success' | 'error' }>`
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: ${({ kind }) =>
+    kind === 'success' ? 'rgba(46, 213, 115, 0.12)' : 'rgba(230, 57, 70, 0.12)'};
+  color: ${({ kind }) => (kind === 'success' ? 'var(--accent-light)' : 'var(--error)')};
+  border: 1px solid
+    ${({ kind }) => (kind === 'success' ? 'rgba(46, 213, 115, 0.35)' : 'rgba(230, 57, 70, 0.35)')};
+`;
+
+interface AdminStoreManagerProps {
+  items: StoreItem[];
+  token: string;
+}
+
+export function AdminStoreManager({ items, token }: AdminStoreManagerProps) {
+  const [storeItems, setStoreItems] = useState<StoreItem[]>(items);
+  const [message, setMessage] = useState<Feedback | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+  const [uploadingImageId, setUploadingImageId] = useState<number | null>(null);
+  const [newImageFile, setNewImageFile] = useState<File | null>(null);
+
+  const resolveErrorMessage = (error: unknown) => {
+    if (error instanceof Error) {
+      return error.message || 'Произошла ошибка. Попробуйте ещё раз.';
+    }
+    return 'Произошла ошибка. Попробуйте ещё раз.';
+  };
+
+  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const name = String(formData.get('name') ?? '').trim();
+    const description = String(formData.get('description') ?? '').trim();
+    const costMana = Number(formData.get('cost_mana') ?? 0);
+    const stock = Number(formData.get('stock') ?? 0);
+
+    if (!name || !description) {
+      setMessage({ kind: 'error', text: 'Заполните название и описание товара.' });
+      return;
+    }
+    if (!newImageFile) {
+      setMessage({ kind: 'error', text: 'Добавьте изображение перед созданием товара.' });
+      return;
+    }
+
+    const payload = new FormData();
+    payload.append('name', name);
+    payload.append('description', description);
+    payload.append('cost_mana', String(costMana));
+    payload.append('stock', String(stock));
+    payload.append('image', newImageFile);
+
+    try {
+      setCreating(true);
+      setMessage(null);
+      const created = await apiFetch<StoreItem>('/api/admin/store/items', {
+        method: 'POST',
+        body: payload,
+        authToken: token
+      });
+      setStoreItems((prev) => [...prev, created]);
+      setMessage({ kind: 'success', text: 'Товар создан. Он сразу появился в витрине.' });
+      setNewImageFile(null);
+      form.reset();
+    } catch (error) {
+      setMessage({ kind: 'error', text: resolveErrorMessage(error) });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleUpdate = (item: StoreItem) => async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    const payload: Record<string, unknown> = {};
+    const name = String(formData.get('name') ?? '').trim();
+    const description = String(formData.get('description') ?? '').trim();
+    const costMana = formData.get('cost_mana');
+    const stock = formData.get('stock');
+
+    if (name && name !== item.name) {
+      payload.name = name;
+    }
+    if (description && description !== item.description) {
+      payload.description = description;
+    }
+    if (costMana !== null && costMana !== '') {
+      const parsed = Number(costMana);
+      if (!Number.isNaN(parsed) && parsed !== item.cost_mana) {
+        payload.cost_mana = parsed;
+      }
+    }
+    if (stock !== null && stock !== '') {
+      const parsed = Number(stock);
+      if (!Number.isNaN(parsed) && parsed !== item.stock) {
+        payload.stock = parsed;
+      }
+    }
+
+    if (Object.keys(payload).length === 0) {
+      setMessage({ kind: 'error', text: 'Измените поля перед сохранением.' });
+      return;
+    }
+
+    try {
+      setUpdatingId(item.id);
+      setMessage(null);
+      const updated = await apiFetch<StoreItem>(`/api/admin/store/items/${item.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+        authToken: token
+      });
+      setStoreItems((prev) => prev.map((candidate) => (candidate.id === item.id ? updated : candidate)));
+      setMessage({ kind: 'success', text: `Товар «${updated.name}» обновлён.` });
+    } catch (error) {
+      setMessage({ kind: 'error', text: resolveErrorMessage(error) });
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const handleImageUpload = (itemId: number) => async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const payload = new FormData();
+    payload.append('image', file);
+
+    try {
+      setUploadingImageId(itemId);
+      setMessage(null);
+      const updated = await apiFetch<StoreItem>(`/api/admin/store/items/${itemId}/image`, {
+        method: 'POST',
+        body: payload,
+        authToken: token
+      });
+      setStoreItems((prev) => prev.map((candidate) => (candidate.id === itemId ? updated : candidate)));
+      setMessage({ kind: 'success', text: `Изображение для «${updated.name}» обновлено.` });
+    } catch (error) {
+      setMessage({ kind: 'error', text: resolveErrorMessage(error) });
+    } finally {
+      setUploadingImageId(null);
+      event.target.value = '';
+    }
+  };
+
+  const handleRemoveImage = async (item: StoreItem) => {
+    if (!item.image_url) {
+      return;
+    }
+    try {
+      setUpdatingId(item.id);
+      setMessage(null);
+      const updated = await apiFetch<StoreItem>(`/api/admin/store/items/${item.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ image_url: null }),
+        authToken: token
+      });
+      setStoreItems((prev) => prev.map((candidate) => (candidate.id === item.id ? updated : candidate)));
+      setMessage({ kind: 'success', text: `Изображение для «${updated.name}» удалено.` });
+    } catch (error) {
+      setMessage({ kind: 'error', text: resolveErrorMessage(error) });
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  return (
+    <SectionCard>
+      <div>
+        <h3>Магазин экипажа</h3>
+        <p style={{ color: 'var(--text-muted)', marginTop: '0.5rem' }}>
+          Управляйте витриной: добавляйте новые призы, обновляйте описания и следите за складом. Изображения
+          загружаются как файлы и сразу становятся доступны пилотам.
+        </p>
+      </div>
+
+      {message && <Message kind={message.kind}>{message.text}</Message>}
+
+      <section>
+        <h4 style={{ marginBottom: '0.75rem' }}>Добавить новый товар</h4>
+        <form onSubmit={handleCreate} className="grid" style={{ gap: '0.75rem' }}>
+          <FieldGroup>
+            <Label>
+              Название
+              <TextInput name="name" placeholder="Например, экскурсия по цехам" required />
+            </Label>
+            <Label>
+              Описание
+              <TextArea name="description" placeholder="Коротко расскажите, что получает пилот" required />
+            </Label>
+            <InlineFields>
+              <Label>
+                Стоимость ⚡
+                <TextInput type="number" min={0} name="cost_mana" defaultValue={100} required />
+              </Label>
+              <Label>
+                Остаток на складе
+                <TextInput type="number" min={0} name="stock" defaultValue={1} required />
+              </Label>
+            </InlineFields>
+            <Label>
+              Изображение товара
+              <FileInput
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                onChange={(event) => setNewImageFile(event.target.files?.[0] ?? null)}
+                required
+              />
+            </Label>
+          </FieldGroup>
+          <button className="primary" type="submit" disabled={creating}>
+            {creating ? 'Сохраняем…' : 'Создать товар'}
+          </button>
+        </form>
+      </section>
+
+      <section>
+        <h4 style={{ marginBottom: '0.75rem' }}>Существующие позиции</h4>
+        {storeItems.length === 0 ? (
+          <p style={{ color: 'var(--text-muted)' }}>Пока нет товаров — добавьте первый приз.</p>
+        ) : (
+          <ItemsGrid>
+            {storeItems.map((item) => (
+              <ItemCard key={item.id}>
+                {item.image_url ? (
+                  <ItemImage src={item.image_url} alt={`Изображение товара «${item.name}»`} loading="lazy" />
+                ) : (
+                  <ImagePlaceholder>Изображение не загружено</ImagePlaceholder>
+                )}
+
+                <form onSubmit={handleUpdate(item)} className="grid" style={{ gap: '0.75rem' }}>
+                  <FieldGroup>
+                    <Label>
+                      Название
+                      <TextInput name="name" defaultValue={item.name} required />
+                    </Label>
+                    <Label>
+                      Описание
+                      <TextArea name="description" defaultValue={item.description} required />
+                    </Label>
+                    <InlineFields>
+                      <Label>
+                        Стоимость ⚡
+                        <TextInput type="number" name="cost_mana" defaultValue={item.cost_mana} min={0} required />
+                      </Label>
+                      <Label>
+                        Остаток
+                        <TextInput type="number" name="stock" defaultValue={item.stock} min={0} required />
+                      </Label>
+                    </InlineFields>
+                  </FieldGroup>
+                  <button className="secondary" type="submit" disabled={updatingId === item.id}>
+                    {updatingId === item.id ? 'Сохраняем…' : 'Сохранить изменения'}
+                  </button>
+                </form>
+
+                <FieldGroup>
+                  <Label>
+                    Обновить изображение
+                    <FileInput
+                      type="file"
+                      accept="image/png,image/jpeg,image/webp"
+                      onChange={handleImageUpload(item.id)}
+                    />
+                  </Label>
+                  <Actions>
+                    <button
+                      type="button"
+                      className="secondary"
+                      onClick={() => handleRemoveImage(item)}
+                      disabled={!item.image_url || updatingId === item.id}
+                    >
+                      Удалить изображение
+                    </button>
+                    {uploadingImageId === item.id && <span style={{ color: 'var(--text-muted)' }}>Загружаем…</span>}
+                  </Actions>
+                </FieldGroup>
+              </ItemCard>
+            ))}
+          </ItemsGrid>
+        )}
+      </section>
+    </SectionCard>
+  );
+}

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import os
 import sys
@@ -17,7 +19,12 @@ from app.db.session import SessionLocal
 from app.models.artifact import Artifact, ArtifactRarity
 from app.models.branch import Branch, BranchMission
 from app.models.coding import CodingChallenge
-from app.models.mission import Mission, MissionCompetencyReward, MissionDifficulty
+from app.models.mission import (
+    Mission,
+    MissionCompetencyReward,
+    MissionDifficulty,
+    MissionFormat,
+)
 from app.models.rank import Rank, RankCompetencyRequirement, RankMissionRequirement
 from app.models.onboarding import OnboardingSlide
 from app.models.store import StoreItem
@@ -27,6 +34,122 @@ from app.models.journal import JournalEntry, JournalEventType
 from app.main import run_migrations
 
 DATA_SENTINEL = settings.sqlite_path.parent / ".seeded"
+
+
+EXCURSION_IMAGE_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAUAAAADICAIAAAAWZq/8AAAM8UlEQVR4nO3ceXgTZR7A8cnVlLRN"
+    "04MeFAot5fIAOeRQqIri9YiiVFEQFAWR9Vh3dUV2H1RUcMWVx+tRWWHhUYHVRWQFDxQBERARUEFA"
+    "Dmk5Cr0oTe82abN/pJ1MkzYNbR/YX/P9PPyRSYa8GZxvZvJmoi5x2m4FgEz68/0CALQcAQOCETAg"
+    "GAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAY"
+    "AQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgB"
+    "A4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAED"
+    "ghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOC"
+    "ETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IR"
+    "MCAYAQOCETAgGAEDghEwIBgBA4IZz/cLOKfMJl167/ABqZa0BLPNYtTplDNlzjy7c8eR8q0HynLt"
+    "jvP9AoGzo0uctvt8v4ZzwWoxzLg5/o5hUWHmxk86al3KZ7vsr32Rt+9E5Tl+bUCLBcspdErHkMlX"
+    "xjRVr6Ioep0yemDkFzPTpoyMPZcvDGiNYAk4QCaD7rk7EmeOSTjfLwQISHB9Bi6prF35w5n1e0v3"
+    "naiwl9eEmQ29k8xjBtkyhtoMep262iPXd9x3ovK/O4rO3ysFAhIsn4H7JIWOHWJ79fO80spa30dH"
+    "XhSx+MGuJqOn4Zwix7BZB6ocrnP4GoGzFiwBN+uBq2OfvT1Re8+Mpdnvf1eoLr55X5fbBtvUxYz5"
+    "R7YeLHPftloMHzzUbVB3i/roG1/mv7gqx2uInonmjCFRg7pbUuLMNovBUePKKXJk5lWt3V2y9pfi"
+    "0yXOFg/k9eKf/ujUwvUFXqPfcIl10YNd1cUF6wpmrzjV1HCD08KmXRM7IMUSFWbIKXJ8u7/0rbX5"
+    "RwuqG/+3C3jT/G9darx5/aweIZq30XGvZX63v1Q7UESofmJ6zFUXRqQlmG0Wg9mkU3x89pN96oJj"
+    "Tb3Udia4TqH9WLTh9P0jY7rEhKj3XHNxhDbgpnS0Gpc/mnJB51D1nhdW5rz1Vb52nehw44t3dRo9"
+    "MFJ7p9mkS0swpyWYR/W13jTAOv71rBYPtHxL4ROj48ND62Y0JqZH+wZ8y6U27eK/t55paqA/XNvx"
+    "r7cmqB8pkmNDJo6IvmNo1COLj6/ZZfdauU02ze3v4ztp6/XVJSZk5eOpSdGmQJ4tSARdwMmxIREd"
+    "Gp+6+ymrQhvw0J7hzT5b52jTR39K7dax7m/VupQnl2Yv29wg+zircdVfuqvrtIz/gUoqaz/ceub+"
+    "kTHuxR4J5mE9w76vP7IpimIx60ddHKEu7swsP3Cy8W/Lbh1smzA82vd+s0n39pQu+fOdPxz2PG2b"
+    "bJrb2CG24b2a+Qd/OiOBer0EXcCzb0+8rp81kDUjQvVhZn1ZVSOfmd16JJg/fCwlwVa3SzmcrocX"
+    "H1+90/sY9frkLtpdvKyqdv6a3DW7inPsjphwY5cY04je4YlR/vbLQAZatKFg8lUx6mFzUnq0NuBr"
+    "+1o7hHjetpZvafLwO2F49Kb9pc/859SRvKrUOPOzGYlXXFDXlUGvmz8pacQzB2vrZwZav2lukRbD"
+    "MxmJza6W3sfzHlRT6/rjkhPr9pQUV9QMTLGsntG92b/eLgVdwGclOtxYVtX4B79+XTs8fH1cVJjB"
+    "vVhRXXv/O8c27ivxWm1IWlh6H8+BxVnruuv1zB2/l7sXc4ocOUWOH+sXWzNQVn71N3uKR/Wte2+6"
+    "8ZLImIhT6ofPMZd6TnHLq2o/bXqC/fjp6nveynLP3h04WXnv21nfze7Vuf64lxJnHnlRxLo9JW2y"
+    "aaq/3ZoQG9H8rmgyeG7vOFK+cnuTWxE8+B7Yn2pnk4ffWWMT1aiKy2vufC3TNypFUa6/pMHRfs1O"
+    "+47A9umzHUhRlHe/Oa3eNhl144ZFuW9bOxiuvMBz7Fq9097oVLzbR9+f0c69VzlcK7Y1OFyP6F0X"
+    "bes3zW1giqXRk3Zfe7lIzkfQBZyZV737WEWjf3LtTq+VC0trAnnO7DOOPcca37d6JJi1i5sazqme"
+    "LT8DKYqy+UDp/mzPo3ePiNbpFEVRbuhv1U4OLdvib2bONxLtcyqKkhJXt0VtsmkGg+6lCUk6f1NX"
+    "Hq9/nqfeHpRquW2wLSI06HZgL0F3Cv3cx6eaeuidqck3a2ZTjxZUO2oC+h64T1LoPyYmPfyv474P"
+    "RVoM2sWi8oDeEVowkNvC9QWvTOzsvt2tY0h6n/Bv95WOGWRTVzicU+X/tNb34FxS0eAea/0UYJts"
+    "2pSRseq8enlV7U9ZFZf3Cmtq5a/3lMz7NPfJm+MVRTHodW/e16UFI7Yzwf4GpoqPNF3Xt8E5YbOH"
+    "lEqHZ8++bbCt0Yuo7Q13a1vDnT5AgQzktnJ7UWGp5zxiUnpMdLjx8t6eJJb7PfwqihLuc0zzmrQv"
+    "ru+5TTZNOzf+yprc7MImv2p2e/XzvL8uP9mCgdqrYAk4IlSvnYb1otMpL9+d5HVVwCd+50h+OVpx"
+    "2ayDP2dVqPc8nZEwrKf30eNQTpV2UTvrE6AAB3Krcri0312P6hsxZWSMsX5u2lnrWvFDkf/hLtR8"
+    "z+zWJ6nBPZl5dVvU+k3T2p9dqf0M78dVF0U0v1LQCJaAU+PNm57teedlUaEm7022WgxvTO5yzcUN"
+    "dotN+0u3HSpTmvb8x6dyihxTFhxVZ3qNet2Cqcle35qs/aVYu3jTwEjtdVSBCHAg1ZKNp9Uzf6Ne"
+    "9+gNcepDX+8uyS/2/pzv5fahUdo3MrNJlzE0SrvC5t/qTkxav2kql0uZsSzbWdv8B5abBkRqD9ob"
+    "9pZ0enDP6Jd+b9m47UCwBKwoSlK0af6kzj/P6714etcnRsdPvTr2sRvj3pmSvH1OL+3FfYqiFJY6"
+    "n1yaHchznjzjmPbusZr6PS82wrhwWrJ2xmjboTLtxYBGvW75oynTR8V2jjaZDLr4SOOAFMuMW+Ln"
+    "T+rcyoFUuXan9itizW80mj9/VhQlOTZkyfRuvTqFmoy6nonmJdO7ddZcO5GVX/3NryVtu2mKoizd"
+    "XBjIDHZEqP75cZ6vi+3lNX9+L6D/TO1Y0E1iWTsYrutn9XMth7285t63jx5r+rpfL1sPlr2wMke9"
+    "DqF/N8vcOzs98YFnx3pk8XHt5UphZv2ssYmzxja4bqGpb4bOaiDVwvUFXm9JiqLk2h0b9jY/Ubxs"
+    "c+H44dEbnu7h+1CtS3n8/RPaw2SbbNrpEuecT7yvG2/UU2MS4iM97yYzl5/kf6ISLEfgAOeTd2WW"
+    "Xzf38Nl+n7lgXYH2t4fjh0ffPcLzxWZesXP0vN99ryJuAf8DqX7OqvDdhA+3nqkJ4Bx15faiuaty"
+    "XD4rVjtdDy06rr26S2mjTZu94pQ9gBns/t0s91wRoy6u3mlf9WNRa8ZtH4LlCLzvROW1cw5PSo++"
+    "tp81zuq91WVVtdsOlS3eeHr9r80fCRv1+PvZPRND1fmeOeM67T9RuTOzrqLTJc4H/nmsV6fQjCG2"
+    "Qd0tqXHmyPqf7BzJrfpqd8mXDT9Ptngg1bvrCwZ1T1YXXS5/v17w8uaX+TuPlD9wdWz/FEuUxZBb"
+    "7Ny4t+Str/Kz8hs5K2nlpm05UNbsvJqiKEa9bt6EJPXjQF6x86llwX7y7BZ0PyfU6ZTkmJC0BLMt"
+    "zKAoSlFZTa7d+Vt2ZSAzKIIY9Lo9L/ex1V/CtfVgWcb8I42u6ef3ffj/FyxHYJXLpRwtqPbz09b2"
+    "ITk2RHuhxdLNzU9fQaKgC7jdMxl03ePN2usTc4oca3x+I4X2gYDbj35dO3wxM833/rmf5AQ4hwdx"
+    "gmUWOmi9t6kwkFkiCMURuB1yuZRcu+PgqapF6wu+3tPCeXWIEHSz0EB7wik0IBgBA4IRMCAYAQOC"
+    "ETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IR"
+    "MCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEw"
+    "IBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAg"
+    "GAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCAY"
+    "AQOCETAgGAEDghEwIBgBA4IRMCAYAQOCETAgGAEDghEwIBgBA4IRMCDY/wBH3KEEDKUJmQAAAABJ"
+    "RU5ErkJggg=="
+)
+
+
+MERCH_IMAGE_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAUAAAADICAIAAAAWZq/8AAAICUlEQVR4nO3bW2xT9wHH8fiSxLHj"
+    "hMQkDhByocDStLTQwjJAWleGFDpGR4aK9rI9lAe0SqNqNSEhdS19qFat2tZq2rRN1Va6h6pUKqom"
+    "dV1vU1tBOyCBcgkEQ1IIgdxMEjuOE1/34OjEcRxTQM3JT/t+nvz/n4tPFH1zTv6JLcea9+UB0GQ1"
+    "+wIA3D4CBoQRMCCMgAFhBAwII2BAGAEDwggYEEbAgDACBoQRMCCMgAFhBAwII2BAGAEDwggYEEbA"
+    "gDACBoQRMCCMgAFhBAwII2BAGAEDwggYEEbAgDACBoQRMCCMgAFhBAwII2BAGAEDwggYEEbAgDAC"
+    "BoQRMCCMgAFhBAwII2BAGAEDwggYEEbAgDACBoQRMCCMgAFhBAwII2BAGAEDwggYEEbAgDACBoQR"
+    "MCCMgAFhBAwII2BAGAEDwggYEEbAgDACBoQRMCCMgAFhBAwII2BAGAEDwggYEEbAgDACBoQRMCCM"
+    "gAFhBAwII2BAGAEDwggYEEbAgDACBoQRMCCMgAFhBAwII2BAGAEDwggYEEbAgDACBoQRMCCMgAFh"
+    "BAwII2BAGAEDwggYEEbAgDACBoQRMCCMgAFhdrMv4P9C5aPra57YljHZc+CD62/8J+v+9b98zLN5"
+    "Tcak75nXRo5f+EauD7K4A5umctt3LHbbzPn8Mnf59+6b++uBIgI2TX65u/yhLKFWbmvKGjYwEwGb"
+    "yduyMWPGWmCv2NpkysVAEQGbybl8sXtVffpM+aY19lKXWdcDOSximSDqD+R7SlKvK1s2BE93GZu8"
+    "LRuy7paDq2Gp5+HVxY01Bd4FNqcjMRGNDI6Mnvlq8P3WUMfVmfvX793p2bTaGHbsfTV4qrP4njrv"
+    "jo3FDTV2d1HEHwy0+Xrf+nTi+o30A513LWr84y+M4cjRDt+zB4zhva8+7aheaAzbWvYnwpGbXjzu"
+    "EAGbYOjz9rL1jak4y9Y3FlaVTfQO5eXllTy4oqjWm9pntP1KfDRcmjPg/HJ33dM7SteuTJ+02W1F"
+    "LkdRrbdia9ONT05dfvlQPDyR+3qqHvtu9ePNeRZLalhYVVbxg297Nj/Q9dLBoc/O3PaXiTnAI7QJ"
+    "krFE/z+/mBxYLJU/mrzrpv9K3HfocO6TFHhK7n755xn1Zih/6L6VL+6yFuTn2ufh+6t3bTHqNVgL"
+    "7Mv2/aT43rrclwFzEbA5Bt49mohEU68XbllrcxY6aipLH1yRmon0Dw8fPpv7DPV7dxZULjCGgVbf"
+    "uT1/atu+/8yu3/k/PmnMu75VXb2rOcd5Kh5ZF2i7eHb3K60//NXZ3a8EWn3GJovVWvfUjpltT25l"
+    "qXweIGBzxAJj/g9PpF7bigoXNq/1bt9gpNL3zpFkIpHjcPeqevf9y4zhmK/H99zroQtXE+OR8Z7B"
+    "rpfeCp3vNrZWbG3KLyue7VQTfUMX978evtyXjMXDl/suPv+PSP+wsdWxxFO6bvImn4wn0w/ML5/1"
+    "nJgzBGyavkOH85KTSXhbNhr/epUIRwbfO5772AXrG9OHA/86lozFp8bJ5PDn54yRxW4rmf1J2/9B"
+    "WyISM4aJSMz/0Yn0HUrWLE+9iI2E0ueLar2lTQ3ch83FIpZpxrsHRlp9qV9i0x+GB99vjYfGcx/r"
+    "qKlIH9bu2V67Z3uO/Z11Vf5ZNo11Xp8x0zvtvZZMri1Hh4LjVwenlpotlhXP/yz3deKbxh3YTFlW"
+    "qpLJvneO3PRAe3HRLb2RvcQ526bEWOYadXxs2o8Pm6vQeN3zt38bTw2YDwjYTIFWX/hKf/rM8H/P"
+    "T1yb7WY5JTYavrV3ss36jbY6CzNmbE5H+jAemip86MjZC8+8Fjzdxd945wkeoU3Wf+hw7ZMtxrDv"
+    "7Zv89ShlvHsg/Q9Il154Y+iz07d3Ac5li4aPtE+fqZr2Xj2D6cNAqy99pdqQ8Y8cmBvcgU3m/+hE"
+    "LDC5ODTWeT14qvPrHDX8xbn0YeWj2T/Y9HV4Nj9gLZj6OW4tsHu+P+2TjIGTl27vzJgD3IFNlojE"
+    "Tu584VaPCn7ZGTzdZfwftXtV/cpfP9578NOxS9digTGby5Ff6rKXFbtWLHE11hRWlbc/8YfZTlVY"
+    "Vbb8uZ92//Xd8Z5Bx2LP0t1b01fUJq75R4523PqXhTlCwKq6fnOw4be7jdjcq+ozPhdhiA6N5jjP"
+    "4HvHFm5Zd89fnsyyLZn86vdvs2o1n/EIrSoyMHLuqT/f+e3R//GXV/+eZW05GY11vvhm+gctMA9x"
+    "BxYW9Qd8zx5w3rXYs2m16+6awkXl9mJHMpmMBcPx4FjUHwz5ekLnu0Md3bnP0/vmJ6H2K94fb3Q1"
+    "LLW7ndEbwZHjF2Z+GgnzkOVY8z6zrwFzKuvHCc27HNwRHqEBYQQMCCNgQBgBA8IIGBDGKjQgjDsw"
+    "IIyAAWEEDAgjYEAYAQPCCBgQRsCAMAIGhBEwIIyAAWEEDAgjYEAYAQPCCBgQRsCAMAIGhBEwIIyA"
+    "AWEEDAgjYEAYAQPCCBgQRsCAMAIGhBEwIIyAAWEEDAgjYEAYAQPCCBgQRsCAMAIGhBEwIIyAAWEE"
+    "DAgjYEAYAQPCCBgQRsCAMAIGhBEwIIyAAWEEDAgjYEAYAQPCCBgQRsCAMAIGhBEwIIyAAWEEDAgj"
+    "YEAYAQPCCBgQRsCAMAIGhBEwIIyAAWEEDAgjYEAYAQPCCBgQRsCAMAIGhBEwIIyAAWEEDAgjYEAY"
+    "AQPCCBgQRsCAMAIGhBEwIIyAAWEEDAgjYEAYAQPCCBgQRsCAMAIGhP0PV3bnAr+LFlUAAAAASUVO"
+    "RK5CYII="
+)
+
+
+def ensure_store_image(filename: str, encoded: str) -> str:
+    """Создаём файл изображения в uploads/store и возвращаем относительный путь."""
+
+    target = settings.uploads_path / "store" / filename
+    if not target.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(base64.b64decode(encoded))
+    return target.relative_to(settings.uploads_path).as_posix()
 
 
 def seed() -> None:
@@ -168,7 +291,12 @@ def seed() -> None:
             description="Мини-курс из 10 задач для проверки синтаксиса и базовой логики.",
             category="training",
         )
-        session.add_all([branch, python_branch])
+        offline_branch = Branch(
+            title="Офлайн мероприятия",
+            description="Экскурсии, лекции и спортивные сборы, которые помогают прочувствовать атмосферу кампуса.",
+            category="event",
+        )
+        session.add_all([branch, python_branch, offline_branch])
         session.flush()
 
         # Миссии
@@ -214,12 +342,64 @@ def seed() -> None:
             difficulty=MissionDifficulty.MEDIUM,
             minimum_rank_id=ranks[0].id,
         )
+        now = datetime.now(timezone.utc)
+        mission_excursion = Mission(
+            title="Экскурсия по кампусу",
+            description="Очное знакомство с производством и инженерными лабораториями Алабуги.",
+            xp_reward=80,
+            mana_reward=40,
+            difficulty=MissionDifficulty.EASY,
+            format=MissionFormat.OFFLINE,
+            minimum_rank_id=ranks[0].id,
+            registration_deadline=now + timedelta(days=2, hours=18),
+            starts_at=now + timedelta(days=3, hours=10),
+            ends_at=now + timedelta(days=3, hours=12),
+            location_title="Точка сбора в холле «Орбита»",
+            location_address="Республика Татарстан, Елабужский район, территория ОЭЗ «Алабуга»",
+            location_url="https://yandex.ru/maps/-/CDuA5Jm0",
+            capacity=25,
+        )
+        mission_lecture = Mission(
+            title="Лекция «Будущее инженерных профессий»",
+            description="Закрытая офлайн-сессия с руководителями направлений и сессией вопросов-ответов.",
+            xp_reward=120,
+            mana_reward=60,
+            difficulty=MissionDifficulty.MEDIUM,
+            format=MissionFormat.OFFLINE,
+            minimum_rank_id=ranks[0].id,
+            registration_deadline=now + timedelta(days=5),
+            starts_at=now + timedelta(days=6, hours=17),
+            ends_at=now + timedelta(days=6, hours=19),
+            location_title="Амфитеатр технопарка",
+            location_address="Корпус «Новые технологии», 2 этаж",
+            location_url="https://yandex.ru/maps/-/CDuA5IKU",
+            capacity=60,
+        )
+        mission_sport = Mission(
+            title="Утренняя пробежка экипажа",
+            description="Лёгкая тренировка и нетворкинг с наставниками перед рабочим днём.",
+            xp_reward=90,
+            mana_reward=50,
+            difficulty=MissionDifficulty.EASY,
+            format=MissionFormat.OFFLINE,
+            minimum_rank_id=ranks[0].id,
+            registration_deadline=now + timedelta(days=1, hours=20),
+            starts_at=now + timedelta(days=2, hours=7),
+            ends_at=now + timedelta(days=2, hours=8, minutes=30),
+            location_title="Беговая дорожка возле корпуса «Космодром»",
+            location_address="Променад вокруг учебного центра",
+            location_url="https://yandex.ru/maps/-/CDuA5Y1n",
+            capacity=30,
+        )
         session.add_all([
             mission_documents,
             mission_resume,
             mission_interview,
             mission_onboarding,
             mission_python_basics,
+            mission_excursion,
+            mission_lecture,
+            mission_sport,
         ])
         session.flush()
 
@@ -250,6 +430,21 @@ def seed() -> None:
                     competency_id=competencies[2].id,
                     level_delta=1,
                 ),
+                MissionCompetencyReward(
+                    mission_id=mission_excursion.id,
+                    competency_id=competencies[5].id,
+                    level_delta=1,
+                ),
+                MissionCompetencyReward(
+                    mission_id=mission_lecture.id,
+                    competency_id=competencies[0].id,
+                    level_delta=1,
+                ),
+                MissionCompetencyReward(
+                    mission_id=mission_sport.id,
+                    competency_id=competencies[3].id,
+                    level_delta=1,
+                ),
             ]
         )
 
@@ -260,6 +455,9 @@ def seed() -> None:
                 BranchMission(branch_id=branch.id, mission_id=mission_interview.id, order=3),
                 BranchMission(branch_id=branch.id, mission_id=mission_onboarding.id, order=4),
                 BranchMission(branch_id=python_branch.id, mission_id=mission_python_basics.id, order=1),
+                BranchMission(branch_id=offline_branch.id, mission_id=mission_excursion.id, order=1),
+                BranchMission(branch_id=offline_branch.id, mission_id=mission_sport.id, order=2),
+                BranchMission(branch_id=offline_branch.id, mission_id=mission_lecture.id, order=3),
             ]
         )
 
@@ -376,6 +574,9 @@ def seed() -> None:
         )
 
         # Магазин
+        excursion_image = ensure_store_image("excursion.png", EXCURSION_IMAGE_B64)
+        merch_image = ensure_store_image("merch.png", MERCH_IMAGE_B64)
+
         session.add_all(
             [
                 StoreItem(
@@ -383,12 +584,14 @@ def seed() -> None:
                     description="Личный тур по цехам Алабуги",
                     cost_mana=200,
                     stock=5,
+                    image_url=excursion_image,
                 ),
                 StoreItem(
                     name="Мерч экипажа",
                     description="Футболка с эмблемой миссии",
                     cost_mana=150,
                     stock=10,
+                    image_url=merch_image,
                 ),
             ]
         )


### PR DESCRIPTION
## Summary
- extend mission schema with offline metadata, a registration table, and an Alembic upgrade so legacy databases gain the new columns
- expose registration state through candidate and HR APIs, seed three showcase events, and adjust mission services to handle capacity and deadlines safely
- surface offline missions in the UI with booking cards, an HR editor for schedules, and a new registration panel for pilots

## Testing
- `PYTHONPATH=backend python - <<'PY'\nfrom app.main import run_migrations\nrun_migrations()\nprint('migrations: ok')\nPY`
- `PYTHONPATH=backend python scripts/seed_data.py`
- `PYTHONPATH=backend python - <<'PY'\nfrom fastapi.testclient import TestClient\nfrom app.main import app\nclient = TestClient(app)\nlogin = client.post('/auth/login', json={'email': 'candidate@alabuga.space', 'password': 'orbita123'})\nassert login.status_code == 200, login.text\ncandidate_token = login.json()['access_token']\nheaders = {'Authorization': f'Bearer {candidate_token}'}\nmissions_resp = client.get('/api/missions/', headers=headers)\nassert missions_resp.status_code == 200, missions_resp.text\nmissions = missions_resp.json()\noffline = [m for m in missions if m['format'] == 'offline']\nprint('offline missions', len(offline))\nassert offline, 'offline missions missing'\nfirst_offline_id = offline[0]['id']\n\nbefore = client.get(f"/api/missions/{first_offline_id}", headers=headers)\nassert before.status_code == 200, before.text\nbefore_data = before.json()\nprint('registered before', before_data['is_registered'], 'spots_left', before_data['spots_left'])\n\nregister_resp = client.post(f"/api/missions/{first_offline_id}/register", headers=headers)\nassert register_resp.status_code == 200, register_resp.text\n\nafter = client.get(f"/api/missions/{first_offline_id}", headers=headers)\nassert after.status_code == 200, after.text\nafter_data = after.json()\nprint('registered after', after_data['is_registered'], 'spots_left', after_data['spots_left'])\nassert after_data['is_registered'] is True\nPY`
- `PYTHONPATH=backend python - <<'PY'\nfrom fastapi.testclient import TestClient\nfrom app.main import app\nclient = TestClient(app)\nlogin = client.post('/auth/login', json={'email': 'hr@alabuga.space', 'password': 'orbita123'})\nassert login.status_code == 200, login.text\nheaders = {'Authorization': f"Bearer {login.json()['access_token']}"}\nmissions = client.get('/api/admin/missions', headers=headers)\nassert missions.status_code == 200, missions.text\noffline = [m for m in missions.json() if m['format'] == 'offline']\nprint('admin offline missions', len(offline))\nassert offline, 'HR missions missing offline info'\nprint('sample capacity', offline[0]['capacity'])\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68dad6a896cc832f90ad022c2cf461f9