### PR TITLE
Support uploading images for store items

### DIFF
--- a/backend/app/db/seed/store.py
+++ b/backend/app/db/seed/store.py
@@ -13,14 +13,12 @@ def seed_store_items(session: Session) -> list[StoreItem]:
             description="Личный тур по цехам Алабуги",
             cost_mana=200,
             stock=5,
-            image_url="/store/excursion-alabuga.svg",
         ),
         StoreItem(
             name="Мерч экипажа",
             description="Футболка с эмблемой миссии",
-            cost_mana=150,
+            cost_mана=150,
             stock=10,
-            image_url="/store/alabuga-crew-shirt.svg",
         ),
     ]
     session.add_all(items)

--- a/backend/app/services/store.py
+++ b/backend/app/services/store.py
@@ -9,6 +9,7 @@ from app.models.journal import JournalEventType
 from app.models.store import Order, OrderStatus, StoreItem
 from app.models.user import User
 from app.services.journal import log_event
+from app.schemas.store import StoreItemRead
 
 
 def create_order(db: Session, user: User, item: StoreItem, comment: str | None) -> Order:
@@ -59,3 +60,20 @@ def update_order_status(db: Session, order: Order, status_: OrderStatus) -> Orde
         )
 
     return order
+
+
+def serialize_store_item(item: StoreItem) -> StoreItemRead:
+    """Преобразуем товар в схему ответа с готовой ссылкой на изображение."""
+
+    image_url = None
+    if item.image_url:
+        image_url = f"/api/store/items/{item.id}/image"
+
+    return StoreItemRead(
+        id=item.id,
+        name=item.name,
+        description=item.description,
+        cost_mana=item.cost_mana,
+        stock=item.stock,
+        image_url=image_url,
+    )

--- a/frontend/src/components/admin/AdminStoreManager.tsx
+++ b/frontend/src/components/admin/AdminStoreManager.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormEvent, useMemo, useState } from 'react';
+import { ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { apiFetch } from '../../lib/api';
@@ -24,7 +24,6 @@ interface FormState {
   description: string;
   cost_mana: number;
   stock: number;
-  image_url: string;
 }
 
 const emptyForm: FormState = {
@@ -32,7 +31,6 @@ const emptyForm: FormState = {
   description: '',
   cost_mana: 0,
   stock: 0,
-  image_url: '',
 };
 
 export function AdminStoreManager({ token, items }: Props) {
@@ -42,12 +40,45 @@ export function AdminStoreManager({ token, items }: Props) {
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(null);
+  const [removeImage, setRemoveImage] = useState(false);
+  const objectUrlRef = useRef<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const itemById = useMemo(() => new Map(items.map((item) => [item.id, item])), [items]);
+
+  const updatePreview = (url: string | null, isObjectUrl = false) => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+    if (isObjectUrl && url) {
+      objectUrlRef.current = url;
+    }
+    setImagePreview(url);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    };
+  }, []);
 
   const resetForm = () => {
     setForm({ ...emptyForm });
     setSelectedId('new');
+    setImageFile(null);
+    setCurrentImageUrl(null);
+    setRemoveImage(false);
+    updatePreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
   };
 
   const handleSelect = (id: number | 'new') => {
@@ -56,6 +87,10 @@ export function AdminStoreManager({ token, items }: Props) {
     setSelectedId(id);
     if (id === 'new') {
       setForm({ ...emptyForm });
+      setImageFile(null);
+      setCurrentImageUrl(null);
+      setRemoveImage(false);
+      updatePreview(null);
     } else {
       const item = itemById.get(id);
       if (item) {
@@ -65,10 +100,48 @@ export function AdminStoreManager({ token, items }: Props) {
           description: item.description,
           cost_mana: item.cost_mana,
           stock: item.stock,
-          image_url: item.image_url ?? '',
         });
+        setCurrentImageUrl(item.image_url ?? null);
+        setImageFile(null);
+        setRemoveImage(false);
+        updatePreview(item.image_url ?? null);
       }
     }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    setStatus(null);
+    setError(null);
+
+    if (file) {
+      setImageFile(file);
+      setRemoveImage(false);
+      const previewUrl = URL.createObjectURL(file);
+      updatePreview(previewUrl, true);
+    } else {
+      setImageFile(null);
+      updatePreview(removeImage ? null : currentImageUrl, false);
+    }
+  };
+
+  const handleClearSelectedFile = () => {
+    setImageFile(null);
+    updatePreview(removeImage ? null : currentImageUrl, false);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleToggleRemoveImage = () => {
+    setRemoveImage((prev) => {
+      const next = !prev;
+      updatePreview(next ? null : currentImageUrl, false);
+      return next;
+    });
   };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -78,33 +151,55 @@ export function AdminStoreManager({ token, items }: Props) {
     setError(null);
 
     try {
-      const payload = {
-        name: form.name.trim(),
-        description: form.description.trim(),
-        cost_mana: form.cost_mana,
-        stock: form.stock,
-        image_url: form.image_url.trim() === '' ? null : form.image_url.trim(),
-      };
+      const trimmedName = form.name.trim();
+      const trimmedDescription = form.description.trim();
 
-      if (!payload.name || !payload.description) {
+      if (!trimmedName || !trimmedDescription) {
         throw new Error('Название и описание не должны быть пустыми.');
       }
 
+      const formData = new FormData();
+      formData.append('name', trimmedName);
+      formData.append('description', trimmedDescription);
+      formData.append('cost_mana', String(form.cost_mana));
+      formData.append('stock', String(form.stock));
+
+      if (imageFile) {
+        formData.append('image', imageFile);
+      }
+
+      if (removeImage && selectedId !== 'new') {
+        formData.append('remove_image', 'true');
+      }
+
       if (selectedId === 'new') {
-        await apiFetch('/api/admin/store/items', {
+        await apiFetch<StoreItem>('/api/admin/store/items', {
           method: 'POST',
-          body: JSON.stringify(payload),
+          body: formData,
           authToken: token,
         });
         setStatus('Товар добавлен. Мы обновили список, можно проверить карточку ниже.');
         resetForm();
       } else {
-        await apiFetch(`/api/admin/store/items/${selectedId}`, {
+        const saved = await apiFetch<StoreItem>(`/api/admin/store/items/${selectedId}`, {
           method: 'PATCH',
-          body: JSON.stringify(payload),
+          body: formData,
           authToken: token,
         });
         setStatus('Изменения сохранены. Страница магазина обновится автоматически.');
+        setForm({
+          name: saved.name,
+          description: saved.description,
+          cost_mana: saved.cost_mana,
+          stock: saved.stock,
+        });
+        setCurrentImageUrl(saved.image_url ?? null);
+        setImageFile(null);
+        setRemoveImage(false);
+        updatePreview(saved.image_url ?? null, false);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
       }
 
       router.refresh();
@@ -204,17 +299,51 @@ export function AdminStoreManager({ token, items }: Props) {
 
         <div>
           <label className="label" htmlFor="store-image">
-            Ссылка на изображение
+            Изображение товара
           </label>
+          {imagePreview && (
+            <img
+              src={imagePreview}
+              alt={form.name || 'Превью товара'}
+              style={{
+                width: '100%',
+                maxHeight: '200px',
+                borderRadius: '10px',
+                marginBottom: '0.75rem',
+                objectFit: 'cover',
+              }}
+            />
+          )}
           <input
             id="store-image"
-            value={form.image_url}
-            onChange={(event) => setForm((prev) => ({ ...prev, image_url: event.target.value }))}
-            placeholder="Например, /store/excursion-alabuga.svg"
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            onChange={handleImageChange}
+            disabled={saving}
           />
           <small style={{ color: 'var(--text-muted)' }}>
-            Изображение можно сохранить в public/store и указать относительный путь.
+            Загрузите файл JPG, PNG или WEBP. Он сохранится в директории uploads на сервере.
           </small>
+          {(imageFile || imagePreview) && (
+            <div style={{ marginTop: '0.75rem', display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+              {imageFile && (
+                <button type="button" className="secondary" onClick={handleClearSelectedFile} disabled={saving}>
+                  Очистить выбранный файл
+                </button>
+              )}
+              {selectedId !== 'new' && currentImageUrl && !imageFile && (
+                <button type="button" className="secondary" onClick={handleToggleRemoveImage} disabled={saving}>
+                  {removeImage ? 'Отменить удаление' : 'Удалить текущее изображение'}
+                </button>
+              )}
+            </div>
+          )}
+          {removeImage && (
+            <small style={{ color: 'var(--error)' }}>
+              Изображение будет удалено после сохранения изменений.
+            </small>
+          )}
         </div>
 
         <button className="primary" type="submit" disabled={saving}>


### PR DESCRIPTION
## Summary
- switch the admin store endpoints to accept multipart forms and persist uploaded item images on disk
- expose store item images through a new public API endpoint and serialize items with API-based image URLs
- update the HR panel to upload image files with previews and removal controls instead of entering project-relative paths

## Testing
- npm run lint
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd813aaf1c832f9d43d31d60875acf