### PR TITLE
Fix admin mission document downloads

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,9 @@
 const CLIENT_API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 const SERVER_API_URL = process.env.NEXT_INTERNAL_API_URL || CLIENT_API_URL;
 
+export const clientApiUrl = CLIENT_API_URL;
+export const serverApiUrl = SERVER_API_URL;
+
 export interface RequestOptions extends RequestInit {
   authToken?: string;
 }


### PR DESCRIPTION
## Summary
- allow the admin submission card to download documents with the HR token
- export the client API URL so the download helper can call the backend directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e06133dafc832f9c24d0ed65078bc4